### PR TITLE
Rewrite README and review logic of method shareSecret

### DIFF
--- a/src/Secretin.js
+++ b/src/Secretin.js
@@ -325,28 +325,29 @@ class Secretin {
       .then((secret) => this.editSecret(hashedTitle, secret));
   }
 
-  shareSecret(hashedTitle, friendName, type, rights) {
-    if (type === 'folder') {
-      return new Promise((resolve, reject) => {
-        let hashedFolder = false;
-        Object.keys(this.currentUser.metadatas).forEach((hash) => {
-          const secretMetadatas = this.currentUser.metadatas[hash];
-          if (secretMetadatas.type === 'folder'
-              && secretMetadatas.title === friendName) {
-            hashedFolder = hash;
-          }
-        });
-        if (hashedFolder === false) {
-          reject('Folder not found');
-        } else if (hashedTitle === hashedFolder) {
-          reject('You can\'t put this folder in itself.');
-        } else {
-          resolve(this.addSecretToFolder(hashedTitle, hashedFolder));
+  // this one should disappear
+  shareFolder(hashedTitle, folderName) {
+    return new Promise((resolve, reject) => {
+      let hashedFolder = false;
+      Object.keys(this.currentUser.metadatas).forEach((hash) => {
+        const secretMetadatas = this.currentUser.metadatas[hash];
+        if (secretMetadatas.type === 'folder'
+            && secretMetadatas.title === folderName) {
+          hashedFolder = hash;
         }
       });
-    }
+      if (hashedFolder === false) {
+        reject('Folder not found');
+      } else if (hashedTitle === hashedFolder) {
+        reject('You can\'t put this folder in itself.');
+      } else {
+        resolve(this.addSecretToFolder(hashedTitle, hashedFolder));
+      }
+    });
+  }
+  //
 
-
+  shareSecret(hashedTitle, friendName, rights) {
     let sharedSecretObjects;
     const friend = new User(friendName);
     return this.api.getPublicKey(friend.username)

--- a/test/secretRights.test.js
+++ b/test/secretRights.test.js
@@ -42,9 +42,9 @@ describe('Secret accesses', () => {
     .then(() => this.secretin.addSecret(secretTitle, secretContent))
     .then((hashedTitle) => {
       secretId = hashedTitle;
-      return this.secretin.shareSecret(secretId, userRead, secretTitle, 0);
+      return this.secretin.shareSecret(secretId, userRead, 0);
     })
-    .then(() => this.secretin.shareSecret(secretId, userReadWrite, secretTitle, 1));
+    .then(() => this.secretin.shareSecret(secretId, userReadWrite, 1));
   });
 
   describe('No access user', () => {
@@ -62,7 +62,7 @@ describe('Secret accesses', () => {
 
     it('Should not be able to share', () =>
       this.secretin.loginUser(userNoAccess, passwordNoAccess)
-        .then(() => this.secretin.shareSecret(secretId, userRead, secretTitle, 0))
+        .then(() => this.secretin.shareSecret(secretId, userRead, 0))
         .should.be.rejectedWith('You don\'t have this secret')
     );
 
@@ -111,7 +111,7 @@ describe('Secret accesses', () => {
 
     it('Should not be able to share', () =>
       this.secretin.loginUser(userRead, passwordRead)
-        .then(() => this.secretin.shareSecret(secretId, userNoAccess, secretTitle, 0))
+        .then(() => this.secretin.shareSecret(secretId, userNoAccess, 0))
         .should.be.rejectedWith(`You can't share secret ${secretId}`)
     );
 
@@ -184,7 +184,7 @@ describe('Secret accesses', () => {
 
     it('Should not be able to share', () =>
       this.secretin.loginUser(userReadWrite, passwordReadWrite)
-        .then(() => this.secretin.shareSecret(secretId, userNoAccess, secretTitle, 0))
+        .then(() => this.secretin.shareSecret(secretId, userNoAccess, 0))
         .should.be.rejectedWith(`You can't share secret ${secretId}`)
     );
 
@@ -257,7 +257,7 @@ describe('Secret accesses', () => {
 
     it('Should be able to share', () =>
       this.secretin.loginUser(userReadWriteShare, passwordReadWriteShare)
-        .then(() => this.secretin.shareSecret(secretId, userNoAccess, passwordNoAccess, 0))
+        .then(() => this.secretin.shareSecret(secretId, userNoAccess, 0))
         .then(() => {
           this.secretin.currentUser.disconnect();
           return this.secretin.loginUser(userNoAccess, passwordNoAccess);
@@ -337,7 +337,7 @@ describe('Secret accesses', () => {
 
     it('Should not be able to share with itself', () =>
       this.secretin.loginUser(userReadWriteShare, passwordReadWriteShare)
-        .then(() => this.secretin.shareSecret(secretId, userReadWriteShare, secretTitle, 0))
+        .then(() => this.secretin.shareSecret(secretId, userReadWriteShare, 0))
         .should.be.rejectedWith('You can\'t share with yourself')
     );
   });


### PR DESCRIPTION
`shareSecret` method waited `type` argument to resolve friendName as a folderName and retrieve `folderId` to do `addSecretToFolder`.

`shareSecret` no longer wait for this. A new method named `shareFolder` exists but will be removed in the future as it's just a wrapper around `addSecretToFolder` which take `folderName` instead of `folderId` and it's app responsability to link `folderName` to `folderId`.