### PR TITLE
During folder deletion, keep list of already parsed folder to prevent loop

### DIFF
--- a/src/Secretin.js
+++ b/src/Secretin.js
@@ -632,15 +632,15 @@ class Secretin {
       });
   }
 
-  deleteSecret(hashedTitle) {
+  deleteSecret(hashedTitle, list = []) {
     let isFolder = Promise.resolve();
     const secretMetadatas = this.currentUser.metadatas[hashedTitle];
     if (typeof (secretMetadatas) === 'undefined') {
       return Promise.reject(new DontHaveSecretError());
     }
-    if (secretMetadatas.type === 'folder') {
+    if (secretMetadatas.type === 'folder' && list.indexOf(hashedTitle) === -1) {
       isFolder = isFolder
-        .then(() => this.deleteFolderSecrets(hashedTitle));
+        .then(() => this.deleteFolderSecrets(hashedTitle, list));
     }
 
     return isFolder
@@ -672,7 +672,8 @@ class Secretin {
     });
   }
 
-  deleteFolderSecrets(hashedFolder) {
+  deleteFolderSecrets(hashedFolder, list) {
+    list.push(hashedFolder);
     return this.api.getSecret(hashedFolder, this.currentUser)
       .then((encryptedSecret) =>
         this.currentUser.decryptSecret(hashedFolder, encryptedSecret))
@@ -680,7 +681,7 @@ class Secretin {
         Object.keys(JSON.parse(secrets)).reduce(
           (promise, hashedTitle) =>
             promise.then(() =>
-              this.deleteSecret(hashedTitle))
+              this.deleteSecret(hashedTitle, list))
           , Promise.resolve()
         )
       )


### PR DESCRIPTION
Metadatas can be fucked to point like this : 

```
Folder1/Folder2/Folder1/...
```
If you delete one of this folder, it loops over and over.

Now it keep tracks of the parsed folder to prevent the loop.