### PR TITLE
ExportDb called Secretin.getDB and trigger cache in browser

### DIFF
--- a/src/Secretin.js
+++ b/src/Secretin.js
@@ -1532,12 +1532,13 @@ class Secretin {
 
   exportDb(password) {
     let oldSecretin;
-    return this.getDb()
-      .then(jsonDB => {
+    return this.api
+      .getDb(this.currentUser, {})
+      .then(db => {
         if (typeof password === 'undefined') {
-          return Promise.resolve(JSON.parse(jsonDB));
+          return Promise.resolve(db);
         }
-        oldSecretin = new Secretin(APIStandalone, JSON.parse(jsonDB));
+        oldSecretin = new Secretin(APIStandalone, JSON.parse(JSON.stringify(db)));
         oldSecretin.currentUser = this.currentUser;
         return oldSecretin
           .changePassword(password)


### PR DESCRIPTION
now it directly calls api.getDB to prevent usage of caching function
which is only used under electron for offline mode