### PR TITLE
Encrypt and decrypt metadata cache to gain precious time

### DIFF
--- a/src/API/Standalone.js
+++ b/src/API/Standalone.js
@@ -429,7 +429,11 @@ class API {
               this.changePassword(hashedUsername, datas.privateKey, datas.pass)
             );
           } else {
-            this.db.users[hashedUsername].options = datas;
+            if (typeof datas.options === 'undefined') {
+              this.db.users[hashedUsername].metadataCache = datas;
+            } else {
+              this.db.users[hashedUsername].options = datas;
+            }
             resolve();
           }
         } else {

--- a/src/Statuses.js
+++ b/src/Statuses.js
@@ -55,6 +55,20 @@ export class DecryptUserOptionsStatus extends Status {
   }
 }
 
+export class DecryptMetadataCacheStatus extends Status {
+  constructor() {
+    super();
+    this.message = 'Decrypt metadata cache';
+  }
+}
+
+export class EndDecryptMetadataStatus extends Status {
+  constructor() {
+    super();
+    this.message = 'End decrypt metadata';
+  }
+}
+
 export class DecryptMetadataStatus extends Status {
   constructor(state, total) {
     super(state, total);
@@ -85,7 +99,9 @@ const Statuses = {
   ImportPublicKeyStatus,
   DecryptPrivateKeyStatus,
   DecryptUserOptionsStatus,
+  DecryptMetadataCacheStatus,
   DecryptMetadataStatus,
+  EndDecryptMetadataStatus,
   GetProtectKeyStatus,
   ImportSecretStatus,
 };

--- a/test/loggedUser.test.js
+++ b/test/loggedUser.test.js
@@ -429,7 +429,7 @@ describe('Logged user', () => {
 
   it('Can refresh infos', () =>
     this.secretin
-      .refreshUser()
+      .refreshUser(true)
       .then(() => this.secretin.currentUser.metadatas)
       .should.eventually.deep.equal({
         [secretId]: {


### PR DESCRIPTION
exportBigPrivateData and exportPrivateData should be merged to simplify API usage...

Basically each time every metadatas are decrypted one by one so it takes some time.

Now each time decryptAllMetadatas ends, the whole metadatas are encrypted in a cached form with one key so next time it starts to quickly decrypt the cached one before decrypting the new "real" one.