### PR TITLE
Remove timeout on web version and fix bytesToASCIIString

### DIFF
--- a/adapters_test/browser/karma.conf.js
+++ b/adapters_test/browser/karma.conf.js
@@ -24,11 +24,11 @@ module.exports = function exports(config) {
 
     client: {
       mocha: {
-        timeout: '10000',
+        timeout: '120000',
       },
     },
 
-    browserNoActivityTimeout: '30000',
+    browserNoActivityTimeout: '240000',
 
 
     // list of files / patterns to load in the browser

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,7 +23,7 @@ module.exports = function exports(config) {
 
     client: {
       mocha: {
-        timeout: '30000',
+        timeout: '120000',
       },
       args: [
         process.env.API_TYPE,
@@ -31,7 +31,7 @@ module.exports = function exports(config) {
       ],
     },
 
-    browserNoActivityTimeout: '60000',
+    browserNoActivityTimeout: '240000',
 
 
     // list of files / patterns to load in the browser

--- a/src/API/Server.js
+++ b/src/API/Server.js
@@ -46,7 +46,8 @@ class API {
         json,
         sig: signature,
         sigTime: now,
-      }));
+      })
+    );
   }
 
   deleteSecret(user, hashedTitle) {
@@ -61,7 +62,8 @@ class API {
         doDELETE(`${this.db}${url}`, {
           sig: signature,
           sigTime: now,
-        }));
+        })
+      );
   }
 
   editSecret(user, secretObject, hashedTitle) {
@@ -86,7 +88,8 @@ class API {
           json,
           sig: signature,
           sigTime: now,
-        }));
+        })
+      );
   }
 
   newKey(user, hashedTitle, secret, wrappedKeys) {
@@ -107,7 +110,8 @@ class API {
           json,
           sig: signature,
           sigTime: now,
-        }));
+        })
+      );
   }
 
   unshareSecret(user, friendNames, hashedTitle) {
@@ -140,7 +144,8 @@ class API {
           json,
           sig: signature,
           sigTime: now,
-        }));
+        })
+      );
   }
 
   shareSecret(user, sharedSecretObjects) {
@@ -159,7 +164,8 @@ class API {
           json,
           sig: signature,
           sigTime: now,
-        }));
+        })
+      );
   }
 
   retrieveUser(username, hash, hashed) {
@@ -207,7 +213,8 @@ class API {
         return user.sign(`${url}|${now}`);
       })
       .then(signature =>
-        doGET(`${this.db}${url}?sig=${signature}&sigTime=${now}`));
+        doGET(`${this.db}${url}?sig=${signature}&sigTime=${now}`, 0)
+      );
   }
 
   getSecret(hashedTitle, user) {
@@ -219,7 +226,8 @@ class API {
         return user.sign(`${url}|${now}`);
       })
       .then(signature =>
-        doGET(`${this.db}${url}?sig=${signature}&sigTime=${now}`));
+        doGET(`${this.db}${url}?sig=${signature}&sigTime=${now}`)
+      );
   }
 
   getHistory(user, hashedTitle) {
@@ -231,7 +239,8 @@ class API {
         return user.sign(`${url}|${now}`);
       })
       .then(signature =>
-        doGET(`${this.db}${url}?sig=${signature}&sigTime=${now}`))
+        doGET(`${this.db}${url}?sig=${signature}&sigTime=${now}`)
+      )
       .then(secret => ({
         iv: secret.iv_history,
         secret: secret.history,
@@ -274,7 +283,8 @@ class API {
           json,
           sig: signature,
           sigTime: now,
-        }));
+        })
+      );
   }
 
   getRescueCodes(user) {
@@ -286,7 +296,8 @@ class API {
         return user.sign(`${url}|${now}`);
       })
       .then(signature =>
-        doGET(`${this.db}${url}?sig=${signature}&sigTime=${now}`));
+        doGET(`${this.db}${url}?sig=${signature}&sigTime=${now}`)
+      );
   }
 
   editUser(user, datas) {
@@ -303,7 +314,8 @@ class API {
           json,
           sig: signature,
           sigTime: now,
-        }));
+        })
+      );
   }
 
   changePassword(user, privateKey, pass) {
@@ -323,7 +335,8 @@ class API {
           json,
           sig: signature,
           sigTime: now,
-        }));
+        })
+      );
   }
 
   testTotp(seed, token) {
@@ -346,7 +359,8 @@ class API {
           json,
           sig: signature,
           sigTime: now,
-        }));
+        })
+      );
   }
 
   deactivateTotp(user) {
@@ -358,7 +372,8 @@ class API {
         return user.sign(`${url}|${now}`);
       })
       .then(signature =>
-        doPUT(`${this.db}${url}?sig=${signature}&sigTime=${now}`, {}));
+        doPUT(`${this.db}${url}?sig=${signature}&sigTime=${now}`, {})
+      );
   }
 
   activateShortLogin(shortpass, user) {
@@ -377,7 +392,8 @@ class API {
           json,
           sig: signature,
           sigTime: now,
-        }));
+        })
+      );
   }
 
   isOnline() {

--- a/src/Secretin.js
+++ b/src/Secretin.js
@@ -259,7 +259,8 @@ class Secretin {
           publicKey,
           pass,
           options
-        ))
+        )
+      )
       .then(() => {
         if (typeof window.process !== 'undefined') {
           // Electron
@@ -277,7 +278,13 @@ class Secretin {
       });
   }
 
-  loginUser(username, password, otp, progress = defaultProgress, forceSync = true) {
+  loginUser(
+    username,
+    password,
+    otp,
+    progress = defaultProgress,
+    forceSync = true
+  ) {
     let key;
     let hash;
     let remoteUser;
@@ -355,13 +362,16 @@ class Secretin {
   }
 
   updateMetadataCache(newMetadata, progress = defaultProgress) {
-    return this.currentUser.decryptAllMetadatas(newMetadata, progress)
-    .then(metadata => {
-      this.currentUser.metadatas = metadata;
-      progress(new EndDecryptMetadataStatus());
-      return this.currentUser.exportBigPrivateData(metadata);
-    })
-    .then(objectMetadataCache => this.api.editUser(this.currentUser, objectMetadataCache))
+    return this.currentUser
+      .decryptAllMetadatas(newMetadata, progress)
+      .then(metadata => {
+        this.currentUser.metadatas = metadata;
+        progress(new EndDecryptMetadataStatus());
+        return this.currentUser.exportBigPrivateData(metadata);
+      })
+      .then(objectMetadataCache =>
+        this.api.editUser(this.currentUser, objectMetadataCache)
+      );
   }
 
   refreshUser(rForceUpdate = false, progress = defaultProgress) {
@@ -385,7 +395,9 @@ class Secretin {
       .then(() => {
         if (typeof remoteUser.metadataCache !== 'undefined') {
           progress(new DecryptMetadataCacheStatus());
-          return this.currentUser.importBigPrivateData(remoteUser.metadataCache);
+          return this.currentUser.importBigPrivateData(
+            remoteUser.metadataCache
+          );
         }
         forceUpdate = true;
         return Promise.resolve({});
@@ -1485,9 +1497,11 @@ class Secretin {
   }
 
   canITryShortLogin() {
-    return this.editableDB &&
+    return (
+      this.editableDB &&
       localStorageAvailable() &&
-      localStorage.getItem(`${Secretin.prefix}username`) !== null;
+      localStorage.getItem(`${Secretin.prefix}username`) !== null
+    );
   }
 
   getSavedUsername() {
@@ -1558,7 +1572,11 @@ class Secretin {
         if (typeof password === 'undefined') {
           return Promise.resolve(db);
         }
-        oldSecretin = new Secretin(this.cryptoAdapter, APIStandalone, JSON.parse(JSON.stringify(db)));
+        oldSecretin = new Secretin(
+          this.cryptoAdapter,
+          APIStandalone,
+          JSON.parse(JSON.stringify(db))
+        );
         oldSecretin.currentUser = this.currentUser;
         return oldSecretin
           .changePassword(password)

--- a/src/User.js
+++ b/src/User.js
@@ -107,7 +107,8 @@ class User {
 
   exportBigPrivateData(data) {
     const result = {};
-    return this.cryptoAdapter.encryptAESGCM256(data)
+    return this.cryptoAdapter
+      .encryptAESGCM256(data)
       .then(secretObject => {
         result.secret = secretObject.secret;
         result.iv = secretObject.iv;
@@ -254,7 +255,7 @@ class User {
       .then(rMetadata => {
         metadata = rMetadata;
         if (typeof encryptedHistory.iv === 'undefined') {
-          return Promise.resolve({})
+          return Promise.resolve({});
         }
         return this.decryptSecret(hashedTitle, encryptedHistory);
       })
@@ -368,20 +369,22 @@ class User {
     const progressStatus = new DecryptMetadataStatus(0, hashedTitles.length);
     progress(progressStatus);
     const metadatas = {};
-    return hashedTitles.reduce(
-      (promise, hashedTitle) =>
-        promise.then(() =>
-          this.decryptSecret(
-            hashedTitle,
-            allMetadatas[hashedTitle]
-          ).then(metadata => {
-            progressStatus.step();
-            progress(progressStatus);
-            metadatas[hashedTitle] = metadata;
-          })
-        ),
-      Promise.resolve()
-    ).then(() => metadatas);
+    return hashedTitles
+      .reduce(
+        (promise, hashedTitle) =>
+          promise.then(() =>
+            this.decryptSecret(
+              hashedTitle,
+              allMetadatas[hashedTitle]
+            ).then(metadata => {
+              progressStatus.step();
+              progress(progressStatus);
+              metadatas[hashedTitle] = metadata;
+            })
+          ),
+        Promise.resolve()
+      )
+      .then(() => metadatas);
   }
 
   activateShortLogin(shortpass, deviceName) {
@@ -429,10 +432,7 @@ class User {
           privateKey: localStorage.getItem(`${Secretin.prefix}privateKey`),
           iv: localStorage.getItem(`${Secretin.prefix}privateKeyIv`),
         };
-        return this.importPrivateKey(
-          protectKey,
-          privateKeyObject
-        );
+        return this.importPrivateKey(protectKey, privateKeyObject);
       });
   }
 }

--- a/src/lib/http.js
+++ b/src/lib/http.js
@@ -1,7 +1,10 @@
-function reqData(path, datas, type) {
+function reqData(path, datas, type, timeout = 10000) {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.timeout = 10000;
+    if (typeof window.process !== 'undefined') {
+      // Electron
+      xhr.timeout = timeout;
+    }
     xhr.open(type, encodeURI(path));
     xhr.setRequestHeader('Content-Type', 'application/json');
     xhr.onload = () => {
@@ -22,10 +25,13 @@ function reqData(path, datas, type) {
   });
 }
 
-export function doGET(path) {
+export function doGET(path, timeout = 6000) {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.timeout = 6000;
+    if (typeof window.process !== 'undefined') {
+      // Electron
+      xhr.timeout = timeout;
+    }
     xhr.open('GET', encodeURI(path));
     xhr.onload = () => {
       const datas = JSON.parse(xhr.responseText);
@@ -45,14 +51,14 @@ export function doGET(path) {
   });
 }
 
-export function doPOST(path, datas) {
-  return reqData(path, datas, 'POST');
+export function doPOST(path, datas, timeout = 10000) {
+  return reqData(path, datas, 'POST', timeout);
 }
 
-export function doPUT(path, datas) {
-  return reqData(path, datas, 'PUT');
+export function doPUT(path, datas, timeout = 10000) {
+  return reqData(path, datas, 'PUT', timeout);
 }
 
-export function doDELETE(path, datas) {
-  return reqData(path, datas, 'DELETE');
+export function doDELETE(path, datas, timeout = 10000) {
+  return reqData(path, datas, 'DELETE', timeout);
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -60,7 +60,12 @@ export function hexStringToAscii(hexx) {
 }
 
 export function bytesToASCIIString(bytes) {
-  return String.fromCharCode.apply(null, new Uint8Array(bytes));
+  // String.fromCharCode.apply(null, new Uint8Array(bytes)) trigger Maximum call stack size exceeded
+  const array = new Uint8Array(bytes);
+  return array.reduce(
+    (str, charIndex) => str + String.fromCharCode(charIndex),
+    ''
+  );
 }
 
 export function generateRandomNumber(max) {
@@ -84,7 +89,7 @@ export function generateSeed() {
   for (i = 0; i < buf.length; i++) {
     byte = buf[i];
 
-    symbol = carry | byte >> shift;
+    symbol = carry | (byte >> shift);
     output += alphabet[symbol & 0x1f];
 
     if (shift > 5) {


### PR DESCRIPTION
`bytesToASCIIString` was using `String.fromCharCode.apply` so it triggered a `Maximum call stack size exceeded` error with big blob of data (introduced by the metadatacache)
For slow connection this big blob of data triggered timeout.
Now HTTP request doesn't timeout anymore on web app.
On electron app it doesn't timeout anymore only in the `getUserWithSignature` (which contains this growing blob of metadatacache)