### PR TITLE
Fix password generation

### DIFF
--- a/src/lib/passwordGenerator.js
+++ b/src/lib/passwordGenerator.js
@@ -3,7 +3,7 @@ const vowels = 'aeiouy';
 const consonants = 'bcdfghjklmnpqrstvwxz';
 const numbers = '0123456789';
 
-const similarChars = '[ilLI|`oO0';
+const similarChars = '[]i;lLI|`\'"oO09g8B';
 
 export function generateRandomNumber(max) {
   const randomValues = new Uint8Array(1);
@@ -30,7 +30,7 @@ export const checkStrictRules = (str, rules) =>
   rules.symbols === hasSymbol(str);
 
 export const buildCharset = (options) => {
-  const charset = [];
+  let charset = [];
 
   const letters = vowels + consonants;
 
@@ -46,8 +46,8 @@ export const buildCharset = (options) => {
     charset.push(...[...symbols]);
   }
 
-  if (options.contentRules.similarChars === false) {
-    charset.filter((character) => similarChars.indexOf(character) >= 0);
+  if (options.allowSimilarChars === false) {
+    charset = charset.filter((char) => !similarChars.includes(char));
   }
 
   return charset;

--- a/src/lib/passwordGenerator.js
+++ b/src/lib/passwordGenerator.js
@@ -57,8 +57,7 @@ export const getRandomPassword = (options) => {
   let password = '';
 
   if (options.readable) {
-    let lastCharWasVocal = false; // TODO : rand
-
+    let lastCharWasVocal = Boolean(generateRandomNumber(1));
     for (let i = 0; i < options.length; i += 1) {
       const charset = lastCharWasVocal ? consonants : vowels;
       lastCharWasVocal = !lastCharWasVocal;
@@ -95,7 +94,7 @@ export const generatePassword = (customOptions) => {
 
   const password = getRandomPassword(options);
 
-  if (options.strictRules) {
+  if (options.strictRules && !options.readable) {
     return checkStrictRules(password, contentRules)
       ? password
       : generatePassword(customOptions);

--- a/src/lib/passwordGenerator.js
+++ b/src/lib/passwordGenerator.js
@@ -30,24 +30,24 @@ export const checkStrictRules = (str, rules) =>
   rules.symbols === hasSymbol(str);
 
 export const buildCharset = (options) => {
-  let charset = [];
+  const charset = [];
 
   const letters = vowels + consonants;
 
-  charset.push(...[...letters]);
+  charset.push(...letters);
 
   if (options.contentRules.mixedCase) {
-    charset.push(...[...letters.toUpperCase()]);
+    charset.push(...letters.toUpperCase());
   }
   if (options.contentRules.numbers) {
-    charset.push(...[...numbers]);
+    charset.push(...numbers);
   }
   if (options.contentRules.symbols) {
-    charset.push(...[...symbols]);
+    charset.push(...symbols);
   }
 
   if (options.allowSimilarChars === false) {
-    charset = charset.filter((char) => !similarChars.includes(char));
+    return charset.filter((char) => !similarChars.includes(char));
   }
 
   return charset;

--- a/test/mock.js
+++ b/test/mock.js
@@ -43,6 +43,7 @@ crypto.subtle.generateKey = function generateKey(
 
 // eslint-disable-next-line
 let expectedRandom = 1337;
+crypto.__getRandomValues = crypto.getRandomValues;
 crypto.getRandomValues = function getRandomValues(typedArray) {
   typedArray.fill(expectedRandom);
 };

--- a/test/passwordGenerator.test.js
+++ b/test/passwordGenerator.test.js
@@ -1,4 +1,15 @@
 describe('Password generation', () => {
+  // We need actual random for these tests to avoid infinite recursion
+  // when we retry password generation until we match the rules
+  let mockedGetRandomValues;
+  before(() => {
+    mockedGetRandomValues = crypto.getRandomValues;
+    crypto.getRandomValues = crypto.__getRandomValues;
+  });
+  after(() => {
+    crypto.getRandomValues = mockedGetRandomValues;
+  });
+
   const pw = Secretin.Utils.PasswordGenerator;
 
   describe('hasNumber', () => {
@@ -208,28 +219,17 @@ describe('Password generation', () => {
 
     it('Should generate a password with the proper length', () => {
       const options = {
-        allowSimilarChars: true,
-        contentRules: {
-          numbers: true,
-          mixedCase: true,
-          symbols: true,
-        },
         length: 10,
       };
-      const password = pw.getRandomPassword(options);
+      const password = pw.generatePassword(options);
       password.length.should.equal(10);
     });
 
     it('Should generate a pronounceable password', () => {
       const options = {
         readable: true,
-        contentRules: {
-          numbers: true,
-          mixedCase: true,
-          symbols: false,
-        },
       };
-      const password = pw.getRandomPassword(options);
+      const password = pw.generatePassword(options);
       password.length.should.equal(20);
       // We consider it's pronounceable if there is an alternance of consonants and vowels
       const vowels = 'aeiouy';
@@ -238,7 +238,7 @@ describe('Password generation', () => {
       let lastCharType;
       [...password].forEach((char) => {
         const charType = getCharType(char);
-        expect(charType).not.toBe(lastCharType);
+        expect(charType).not.to.equal(lastCharType);
         lastCharType = charType;
       });
     });

--- a/test/passwordGenerator.test.js
+++ b/test/passwordGenerator.test.js
@@ -200,7 +200,7 @@ describe('Password generation', () => {
       };
       // eslint-disable-next-line
       const expectedCharset = [
-        ...'abcdefghjkmnpqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ!@#$%^&*()+_=}{:;"?.><,~123456789',
+        ...'abcdefhjkmnpqrstuvwxyzACDEFGHJKMNPQRSTUVWXYZ!@#$%^&*()+_=}{:?.><,~1234567',
       ];
       const actualCharset = pw.buildCharset(options);
       expect(actualCharset.sort()).to.deep.equal(expectedCharset.sort());

--- a/test/passwordGenerator.test.js
+++ b/test/passwordGenerator.test.js
@@ -135,9 +135,7 @@ describe('Password generation', () => {
       };
       const expectedCharset = [...'abcdefghijklmnopqrstuvwxyz'];
       const actualCharset = pw.buildCharset(options);
-      for (const char of expectedCharset) {
-        (actualCharset.indexOf(char) >= 0).should.equal(true);
-      }
+      expect(actualCharset.sort()).to.deep.equal(expectedCharset.sort());
     });
 
     it('Should build mixedcase charset when mixedCase rule is set to true', () => {
@@ -153,9 +151,7 @@ describe('Password generation', () => {
         ...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
       ];
       const actualCharset = pw.buildCharset(options);
-      for (const char of expectedCharset) {
-        (actualCharset.indexOf(char) >= 0).should.equal(true);
-      }
+      expect(actualCharset.sort()).to.deep.equal(expectedCharset.sort());
     });
 
     // eslint-disable-next-line
@@ -173,9 +169,7 @@ describe('Password generation', () => {
         ...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()+_=}{[]|:;"?.><,`~',
       ];
       const actualCharset = pw.buildCharset(options);
-      for (const char of expectedCharset) {
-        (actualCharset.indexOf(char) >= 0).should.equal(true);
-      }
+      expect(actualCharset.sort()).to.deep.equal(expectedCharset.sort());
     });
 
     it('Should build mixedcase+symbols+numbers charset when all rules are set to true', () => {
@@ -192,9 +186,7 @@ describe('Password generation', () => {
         ...'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()+_=}{[]|:;"?.><,`~0123456789',
       ];
       const actualCharset = pw.buildCharset(options);
-      for (const char of expectedCharset) {
-        (actualCharset.indexOf(char) >= 0).should.equal(true);
-      }
+      expect(actualCharset.sort()).to.deep.equal(expectedCharset.sort());
     });
 
     it('Should skip similar characters if allowSimilarChars option is set to false', () => {
@@ -211,9 +203,7 @@ describe('Password generation', () => {
         ...'abcdefghjkmnpqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ!@#$%^&*()+_=}{:;"?.><,~123456789',
       ];
       const actualCharset = pw.buildCharset(options);
-      for (const char of expectedCharset) {
-        (actualCharset.indexOf(char) >= 0).should.equal(true);
-      }
+      expect(actualCharset.sort()).to.deep.equal(expectedCharset.sort());
     });
 
     it('Should generate a password with the proper length', () => {
@@ -228,6 +218,29 @@ describe('Password generation', () => {
       };
       const password = pw.getRandomPassword(options);
       password.length.should.equal(10);
+    });
+
+    it('Should generate a pronounceable password', () => {
+      const options = {
+        readable: true,
+        contentRules: {
+          numbers: true,
+          mixedCase: true,
+          symbols: false,
+        },
+      };
+      const password = pw.getRandomPassword(options);
+      password.length.should.equal(20);
+      // We consider it's pronounceable if there is an alternance of consonants and vowels
+      const vowels = 'aeiouy';
+      const getCharType = (char) =>
+        vowels.includes(char) ? 'vowel' : 'consonant';
+      let lastCharType;
+      [...password].forEach((char) => {
+        const charType = getCharType(char);
+        expect(charType).not.toBe(lastCharType);
+        lastCharType = charType;
+      });
     });
   });
 });


### PR DESCRIPTION
Tests for password generation were (partly) broken since day one.
This PR fixes the tests, as well as the implementation of `allowSimilarChars` and `readable` options.